### PR TITLE
VRHMDで視聴した際、立体視ができなかった問題を修正

### DIFF
--- a/Assets/VR180-Camera.unity
+++ b/Assets/VR180-Camera.unity
@@ -225,58 +225,47 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470,
-        type: 3}
+    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470,
-        type: 3}
+    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470, type: 3}
       propertyPath: m_LocalPosition.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470,
-        type: 3}
+    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470,
-        type: 3}
+    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470,
-        type: 3}
+    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470,
-        type: 3}
+    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470,
-        type: 3}
+    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470,
-        type: 3}
+    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470,
-        type: 3}
+    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470,
-        type: 3}
+    - target: {fileID: 1819060222249682926, guid: e06d0efbdb13d2e4fa944d7ac2448470, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4010776288071862247, guid: e06d0efbdb13d2e4fa944d7ac2448470,
-        type: 3}
+    - target: {fileID: 4010776288071862247, guid: e06d0efbdb13d2e4fa944d7ac2448470, type: 3}
       propertyPath: m_Name
       value: VR180 Camera
       objectReference: {fileID: 0}

--- a/Assets/marumasa/VR180_Camera/VR180 Camera.prefab
+++ b/Assets/marumasa/VR180_Camera/VR180 Camera.prefab
@@ -25,7 +25,7 @@ Transform:
   m_GameObject: {fileID: 444564375089827091}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.1, y: 0, z: 0}
+  m_LocalPosition: {x: 0.035, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -143,7 +143,7 @@ Transform:
   m_GameObject: {fileID: 1559982978911962028}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.1, y: 0, z: 0}
+  m_LocalPosition: {x: -0.035, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -376,7 +376,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4010776288071862247}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0


### PR DESCRIPTION
VRChatで使用させていただきました。
DeoVRプレイヤーを使い収録した動画をVRHMDで視聴してみたところ、そのままだとうまく立体視できないことに気づきました。
左右のカメラの位置を入れ替えたところ、うまく立体視することができました。

また、立体視した際にVRChat内でHMDを通して見たときよりもスケール感が小さく感じました。
カメラのIPDを人間の目のIPDに近づければ解決すると思いましたので、一旦70cmに変更してみました。

よろしければご確認いただけますと幸いです。